### PR TITLE
Add exclude option

### DIFF
--- a/lib/pass.rb
+++ b/lib/pass.rb
@@ -19,9 +19,15 @@ class Pass
 
     list += SYMBOL_CHARS if @options[:symbols]
 
-    list -= @options[:exclude].split(//) if @options[:exclude]
+    list -= exclude_char_list
 
-    list - AMBIGUOUS_CHARS
+    list
+  end
+
+  def exclude_char_list
+    list = AMBIGUOUS_CHARS
+    list += @options[:exclude].split(//) if @options[:exclude]
+    list
   end
 
   def generate(length = DEFAULT_PASSWORD_LENGTH)

--- a/lib/pass.rb
+++ b/lib/pass.rb
@@ -15,11 +15,13 @@ class Pass
   end
 
   def char_list
-    if @options[:symbols]
-      ALPHABETIC_CHARS + NUMERIC_CHARS + SYMBOL_CHARS - AMBIGUOUS_CHARS
-    else
-      ALPHABETIC_CHARS + NUMERIC_CHARS - AMBIGUOUS_CHARS
-    end
+    list = ALPHABETIC_CHARS + NUMERIC_CHARS
+
+    list += SYMBOL_CHARS if @options[:symbols]
+
+    list -= @options[:exclude].split(//) if @options[:exclude]
+
+    list - AMBIGUOUS_CHARS
   end
 
   def generate(length = DEFAULT_PASSWORD_LENGTH)

--- a/lib/pass/cli.rb
+++ b/lib/pass/cli.rb
@@ -18,6 +18,10 @@ class Pass
         options[:symbols] = true
       end
 
+      opts.on('-e', '--exclude [CHARACTERS]', 'exclude characters') do |value|
+        options[:exclude] = value
+      end
+
       opts.on_tail('-v', '--version', 'show version') do
         puts "pass #{Pass::VERSION}"
         exit 0

--- a/spec/pass_spec.rb
+++ b/spec/pass_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe Pass do
         expect(pass.generate(LONG_ENOUGH_LENGTH)).to match(SYMBOL_CHARS_REGEXP)
       end
     end
+
+    context "with :exclude option" do
+      it "generates a password including symbols" do
+        list = 'ABCDEFGHabcdefgh'
+        pass = Pass.new(exclude: 'ABCDEFGHabcdefgh')
+        expect(pass.generate(LONG_ENOUGH_LENGTH)).not_to match(chars_regexp(list))
+      end
+    end
   end
 
   describe "例外の発生" do

--- a/spec/pass_spec.rb
+++ b/spec/pass_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe Pass do
 
     context "with long enough password length argument" do
       it "generates a password not including ambiguous characters" do
-        expect(@pass.generate(LONG_ENOUGH_LENGTH)).not_to match(AMBIGUOUS_CHARS_REGEXP)
+        result = @pass.generate(LONG_ENOUGH_LENGTH)
+        expect(result).not_to match(AMBIGUOUS_CHARS_REGEXP)
+        expect(result.size).to eq(LONG_ENOUGH_LENGTH)
       end
     end
 
@@ -36,7 +38,9 @@ RSpec.describe Pass do
       end
 
       it "generates a password not including any symbols" do
-        expect(@pass.generate(LONG_ENOUGH_LENGTH)).not_to match(SYMBOL_CHARS_REGEXP)
+        result = @pass.generate(LONG_ENOUGH_LENGTH)
+        expect(result).not_to match(SYMBOL_CHARS_REGEXP)
+        expect(result.size).to eq(LONG_ENOUGH_LENGTH)
       end
     end
 
@@ -48,10 +52,12 @@ RSpec.describe Pass do
     end
 
     context "with :exclude option" do
-      it "generates a password including symbols" do
+      it "generates a password not including specified characters" do
         list = 'ABCDEFGHabcdefgh'
         pass = Pass.new(exclude: 'ABCDEFGHabcdefgh')
-        expect(pass.generate(LONG_ENOUGH_LENGTH)).not_to match(chars_regexp(list))
+        result = pass.generate(LONG_ENOUGH_LENGTH)
+        expect(result).not_to match(chars_regexp(list))
+        expect(result.size).to eq(LONG_ENOUGH_LENGTH)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,13 @@ require 'pass/cli'
 LONG_ENOUGH_LENGTH = 200
 
 def chars_regexp(list)
-  /[#{Regexp.escape(list.join)}]/
+  str = if list.is_a?(Array)
+          list.join
+        else
+          list
+        end
+
+  /[#{Regexp.escape(str)}]/
 end
 
 SYMBOL_CHARS_REGEXP = chars_regexp(Pass::SYMBOL_CHARS - Pass::AMBIGUOUS_CHARS)


### PR DESCRIPTION
Add an 'exclude' option to exclude some characters you want to avoid including in passwords