### PR TITLE
Remove multi_generate method from Pass

### DIFF
--- a/lib/pass.rb
+++ b/lib/pass.rb
@@ -31,7 +31,7 @@ class Pass
   end
 
   def generate(length = DEFAULT_PASSWORD_LENGTH)
-    if !integer?(length) || length < MIN_PASSWORD_LENGTH
+    if length < MIN_PASSWORD_LENGTH
       raise Pass::Error,
             "Invalid Argument: password length must be more than #{MIN_PASSWORD_LENGTH}."
     end
@@ -48,25 +48,11 @@ class Pass
     result
   end
 
-  def multi_generate(num_password, num_character = DEFAULT_PASSWORD_LENGTH)
-    passwords = []
-
-    num_password.times do
-      passwords << generate(num_character)
-    end
-
-    passwords
-  end
-
   def self.generate(num = DEFAULT_PASSWORD_LENGTH)
     new.generate(num)
   end
 
   private
-
-  def integer?(value)
-    value.is_a?(Integer)
-  end
 
   def char_list_size
     char_list.size

--- a/lib/pass/cli.rb
+++ b/lib/pass/cli.rb
@@ -39,7 +39,7 @@ class Pass
 
         pass = Pass.new(**options)
         puts pass.multi_generate(num_passwords.to_i, password_length.to_i)
-      rescue Pass::Error => e
+      rescue Pass::Error, OptionParser::ParseError => e
         warn "Error: #{e.message}"
       end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -10,10 +10,12 @@ RSpec.describe Pass::CLI do
   describe "コマンド用メソッド" do
     before do
       $stdout = StringIO.new
+      $stderr = StringIO.new
     end
 
     after do
       $stdout = STDOUT
+      $stderr = STDERR
     end
 
     it "オプション無しで1個のパスワードが返ってくること" do
@@ -44,8 +46,8 @@ RSpec.describe Pass::CLI do
       end
     end
 
-    it "指定順序が変わっても-cで文字数指定ができること" do
-      argv = %w[-c 16 3] # 16文字 3パスワード
+    it "指定順序が変わっても-lで文字数指定ができること" do
+      argv = %w[-l 16 3] # 16文字 3パスワード
       expect { @cli.exec(argv) }.to raise_error(SystemExit)
       passwords = $stdout.string.chomp.split("\n")
       expect(passwords.size).to eq(3)
@@ -62,6 +64,14 @@ RSpec.describe Pass::CLI do
     it "-hでヘルプ表示をするとSystemExitすること" do
       argv = %w[-h]
       expect { @cli.exec(argv) }.to raise_error(SystemExit)
+    end
+
+    context "with non-integer argument for the number of passwords" do
+      it "displays an error" do
+        argv = ['wrong_arg']
+        expect { @cli.exec(argv) }.to raise_error(SystemExit)
+        expect($stderr.string).to match(/the option must be an integer/)
+      end
     end
   end
 end

--- a/spec/pass_spec.rb
+++ b/spec/pass_spec.rb
@@ -68,16 +68,6 @@ RSpec.describe Pass do
       expect { @pass.generate(0) }.to raise_error(Pass::Error)
       expect { @pass.generate(-10) }.to raise_error(Pass::Error)
     end
-
-    it "不正な文字数を入力すると例外を発生すること" do
-      expect { @pass.generate("abc") }.to raise_error(Pass::Error)
-    end
-  end
-
-  describe "複数パスワードの生成" do
-    it "指定した個数のパスワードを配列で返すこと" do
-      expect(@pass.multi_generate(2).size).to eq(2)
-    end
   end
 
   describe ".generate" do


### PR DESCRIPTION
Pass doesn't have to generate multiple password. Pass::CLI should do it instead.